### PR TITLE
 회원 탈퇴기능 구현 -> 좋아요 한 게시물 없어야 아직 탈퇴가능

### DIFF
--- a/src/components/Modals/SettingModal.jsx
+++ b/src/components/Modals/SettingModal.jsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { InputArea } from '@components/Atoms/Input';
 import { ButtonText } from '@components/Atoms/Button';
+import Save from '@features/mypage/Save';
 
 export default function SettingModal({ onClose, data }) {
   const router = useRouter();
@@ -145,36 +146,29 @@ export default function SettingModal({ onClose, data }) {
                 환경설정
               </p>
             </ModeParentsDiv>
-            <div style={{ marginLeft: '25px' }}>닉네임</div>
-            <EttingDiv>
-              <InputArea
-                style={{ width: '320px' }}
-                size="lg"
-                variant="default"
-                type="text"
-                name="nickName"
-                value={password.nickName}
-                onChange={changePWInputHandler}
-              />
-            </EttingDiv>
-            <div style={{ marginLeft: '25px' }}>이메일</div>
-            <EttingDiv>
-              <InputDiv>{data.email}</InputDiv>
+            <div>닉네임</div>
+            <InputArea
+              size="lg"
+              variant="default"
+              type="text"
+              name="nickName"
+              value={password.nickName}
+              onChange={changePWInputHandler}
+            />
+            <div>이메일</div>
+            <InputDiv>{data.email}</InputDiv>
 
-              <BottomHr />
-
-              <ButtonText
-                style={{ width: '320px' }}
-                label="저장하기"
-                variant="primary"
-                active={true}
-                disabled={isLoading}
-                onClick={() => {
-                  nickName(password);
-                  onClose();
-                }}
-              />
-            </EttingDiv>
+            <BottomHr />
+            <ButtonText
+              label="저장하기"
+              variant="primary"
+              active={true}
+              disabled={isLoading}
+              onClick={() => {
+                nickName(password);
+                onClose();
+              }}
+            />
           </InnerDiv>
         ) : isEditMode === 'password' ? (
           <InnerDiv>
@@ -211,73 +205,117 @@ export default function SettingModal({ onClose, data }) {
                 환경설정
               </p>
             </ModeParentsDiv>
-            <PasswordDiv>
-              <div className="innerpw">
-                <p>새 비밀번호</p>
-                <InputArea
-                  style={{ width: '320px' }}
-                  size="lg"
-                  variant="default"
-                  type="password"
-                  name="password"
-                  placeholder="비밀번호를 입력해주세요."
-                  value={password.password}
-                  onChange={handlePasswordChange}
-                  maxLength="20"
-                  required
-                />
-                <p>비밀번호 확인</p>
-                <InputArea
-                  style={{ width: '320px' }}
-                  size="lg"
-                  variant="default"
-                  type="password"
-                  name="checkPassword"
-                  placeholder="비밀번호를 확인해주세요."
-                  onChange={handlePasswordChange}
-                  required
-                />
-                {passwordError && (
-                  <p style={{ color: 'red', fontSize: '12px' }}>
-                    비밀번호가 일치하지 않습니다.
-                  </p>
-                )}
-                {!passwordError && (
-                  <p style={{ color: 'red', fontSize: '12px' }}>
-                    비밀번호가 일치합니다.
-                  </p>
-                )}
-              </div>
-
+            <p>새 비밀번호</p>
+            <InputArea
+              size="lg"
+              variant="default"
+              type="password"
+              name="password"
+              placeholder="비밀번호를 입력해주세요."
+              value={password.password}
+              onChange={handlePasswordChange}
+              maxLength="20"
+              required
+            />
+            <p>비밀번호 확인</p>
+            <InputArea
+              size="lg"
+              variant="default"
+              type="password"
+              name="checkPassword"
+              placeholder="비밀번호를 확인해주세요."
+              onChange={handlePasswordChange}
+              required
+            />
+            {passwordError && (
+              <p style={{ color: 'red', fontSize: '12px', marginTop: '-5px' }}>
+                비밀번호가 일치하지 않습니다.
+              </p>
+            )}
+            {!passwordError && (
+              <p style={{ color: 'red', fontSize: '12px', marginTop: '-5px' }}>
+                비밀번호가 일치합니다.
+              </p>
+            )}
+            <p
+              style={{
+                margin: '0 auto',
+                fontStyle: 'normal',
+                fontWeight: '400',
+                fontSize: '12px',
+                lineHeight: '16px',
+              }}
+              onClick={() => {
+                if (validateForm(password)) {
+                  changePassword(password);
+                }
+              }}
+            >
+              변경하기
+            </p>
+            <BottomHr />
+            <ButtonText
+              label="저장하기"
+              variant="primary"
+              active={true}
+              disabled={isLoading}
+              onClick={onClose}
+            />
+          </InnerDiv>
+        ) : isEditMode === 'env' ? (
+          <InnerDiv>
+            <EttingDiv>
+              <h3>계정 설정</h3>
+            </EttingDiv>
+            <ModeParentsDiv>
               <p
-                style={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  fontStyle: 'normal',
-                  fontWeight: '400',
-                  fontSize: '12px',
-                  lineHeight: '16px',
-                }}
+                className="unModeP"
                 onClick={() => {
-                  if (validateForm(password)) {
-                    changePassword(password);
-                  }
+                  setIsEditMode('profile');
                 }}
               >
-                변경하기
+                프로필 설정
               </p>
-            </PasswordDiv>
-            <EttingDiv>
-              <PwBottomHr />
-              <ButtonText
-                style={{ width: '320px' }}
-                label="저장하기"
-                variant="primary"
-                active={true}
-                disabled={isLoading}
-                onClick={onClose}
-              />
-            </EttingDiv>
+              <p
+                className="unModeP"
+                onClick={() => {
+                  setIsEditMode('password');
+                }}
+              >
+                비밀번호 설정
+              </p>
+              <div className="modeDiv">
+                <p
+                  className="modeP"
+                  onClick={() => {
+                    setIsEditMode('env');
+                  }}
+                >
+                  환경설정
+                </p>
+                <Hr />
+              </div>
+            </ModeParentsDiv>
+
+            <div>다크모드 넣어주기</div>
+            <p
+              onClick={() => {
+                setIsEditMode('delete');
+              }}
+            >
+              계정 삭제
+            </p>
+            <BottomHr />
+            <ButtonText
+              label="저장하기"
+              variant="primary"
+              active={true}
+              disabled={isLoading}
+              onClick={() => {
+                nickName(password);
+                onClose();
+              }}
+            />
           </InnerDiv>
         ) : (
           <InnerDiv>
@@ -313,34 +351,17 @@ export default function SettingModal({ onClose, data }) {
                 <Hr />
               </div>
             </ModeParentsDiv>
-            <div>
-              <p>테마</p>
-              <p>마케팅 정보 소식</p>
-            </div>
-            <p
-              style={{
-                display: 'flex',
-                justifyContent: 'center',
-
-                color: 'red',
-                fontWeight: '400',
-                fontSize: '12px',
-                lineHeight: '16px',
+            <Save data={data} />
+            <BottomHr />
+            <ButtonText
+              label="이전으로"
+              variant="primary"
+              active={true}
+              disabled={isLoading}
+              onClick={() => {
+                setIsEditMode('env');
               }}
-            >
-              계정 삭제
-            </p>
-            <EttingDiv>
-              <BottomHr />
-              <ButtonText
-                style={{ width: '320px' }}
-                label="저장하기"
-                variant="primary"
-                active={true}
-                disabled={isLoading}
-                onClick={onClose}
-              />
-            </EttingDiv>
+            />
           </InnerDiv>
         )}
 
@@ -372,6 +393,7 @@ const ModalDiv = styled.div`
   /* mix-blend-mode: darken; */
   z-index: 999;
   .modal-overlay {
+    padding: 20px 40px;
     border-radius: 20px;
     position: fixed;
     transform: translate(-50%, -50%);
@@ -382,9 +404,9 @@ const ModalDiv = styled.div`
     justify-content: center;
     background-color: #ffff;
     z-index: 1000;
-    width: 416px;
-    height: 620px;
-    /* padding: 21px 48px; */
+    max-width: 400px;
+    min-width: 280px;
+    width: 50%;
     border: 1px solid #939aa0;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   }
@@ -394,7 +416,7 @@ const InnerDiv = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  /* align-content: center; */
+  align-content: center;
   row-gap: 10px;
   .InputArea {
     border-color: #9fa4a9;
@@ -405,9 +427,8 @@ const InnerDiv = styled.div`
 `;
 const InputDiv = styled.div`
   border: 1px solid #9fa4a9;
-  padding: 12px;
+  padding: 10px;
   border-radius: 8px;
-  width: 320px;
   color: #9fa4a9;
   background-color: #f7f8f9;
 `;
@@ -417,9 +438,6 @@ const EttingDiv = styled.div`
   /* justify-content: center; */
   flex-direction: column;
   align-items: center;
-  .h3 {
-    block-size: fit-content;
-  }
 `;
 const FindButton = styled.button`
   border: none;
@@ -443,14 +461,6 @@ const ModeParentsDiv = styled.div`
     flex-direction: column;
   }
 `;
-
-const PasswordDiv = styled.div`
-  height: fit-content;
-  block-size: fit-content;
-  .innerpw {
-    margin-left: 23px;
-  }
-`;
 const Hr = styled.hr`
   border: 0.5px solid #ff4840;
   width: 60px;
@@ -464,13 +474,5 @@ const BottomHr = styled.hr`
   width: 368px;
   height: 0px;
   border-bottom: 0px;
-  margin-top: 220px;
-`;
-
-const PwBottomHr = styled.hr`
-  border: 0.5px solid#E8EBED;
-  width: 368px;
-  height: 0px;
-  border-bottom: 0px;
-  margin-top: 90px;
+  margin-top: 170px;
 `;

--- a/src/features/mypage/Save.js
+++ b/src/features/mypage/Save.js
@@ -4,7 +4,11 @@ import { InputArea } from '@components/Atoms/Input';
 import { ButtonText } from '@components/Atoms/Button';
 import { apis } from '@shared/axios';
 import { cookies } from '@shared/cookie';
+import { useRouter } from 'next/router';
+
 const Save = ({ data }) => {
+  const router = useRouter();
+  console.log('data save', data);
   const queryClient = useQueryClient();
   const [userOut, setUserOut] = useState({
     password: '',
@@ -16,6 +20,7 @@ const Save = ({ data }) => {
   };
 
   const token = cookies.get('access_token');
+
   const { mutate: deleteId } = useMutation({
     mutationFn: async (payload) => {
       console.log('data', payload);
@@ -33,6 +38,7 @@ const Save = ({ data }) => {
       window.confirm('정말 탈퇴 하시겠습니까?');
       cookies.remove('access_token');
       cookies.remove('refresh_token');
+      router.push('/');
     },
     onError: () => {
       alert('다시 한 번 시도해주십시오');


### PR DESCRIPTION
회원 탈퇴 기능을 만들었습니다. 
기존에 이미 components 폴더에 Save.js 로 만들었었는데 
해당 api가 delete함수로 삭제하는데 payload값을 전달해야 하는 상황이었어서 정상작동이 되지 않아 수정을 요청드렸고, 
그 과정속에 디자인도 수정이 돼서 기존 것을 조금 수정하여 넣어줬습니다. 

Method = delete -> put 으로 매서드 변동이 있었습니다. 
인자는 id, password 값을 보내주면 됐고,
id 값은 상위 폴더인 마이페이지로부터 props로 쭉 내려와 가져와주고 password는 사용자가 직접 쳐서 검증하는 방식으로 진행했습니다. 

현재 시각 4월 19이리 12:21 부터 다음날 오후 일부까지는 좋아요나 데이터를 생성한 값이 없어야 탈퇴가 가능하고 
이 부분은 서버에서 다시 수정해서 올려주시기로 했습니다. 