### PR TITLE
[fix]contextAPI로 props -> react-query로 props전달.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-kakao-maps-sdk": "^1.1.8",
     "react-query": "^3.39.3",
     "react-redux": "^8.0.5",
+    "react-router-dom": "^6.10.0",
     "react-share": "^4.4.1",
     "styled-components": "^5.3.9",
     "universal-cookie": "^4.0.4",

--- a/src/components/Modals/SearchKeywordModalPortal.jsx
+++ b/src/components/Modals/SearchKeywordModalPortal.jsx
@@ -3,16 +3,17 @@ import KeywordSearchModal from '@components/Modals/SearchKeywordModal';
 import React, { createContext, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { apis } from '@shared/axios';
-import { useMutation } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { FlexRow } from '@components/Atoms/Flex';
 import { WebWrapper, WebWrapperHeight } from '@components/Atoms/Wrapper';
 import styled from 'styled-components';
 import MapMidPoint from '@features/map/MapMidPoint';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
-// createContext 함수를 사용하여 컨텍스트 생성(midPoint props MapMidPoint.js로 전달 위해)
-export const MidPointContext = createContext({});
+// // createContext 함수를 사용하여 컨텍스트 생성(midPoint props MapMidPoint.js로 전달 위해)
+// export const MidPointContext = createContext({});
 //  Modal Portal(Landing) Page
 function SearchedKeywordLandingPage() {
     //  Input Box 갯수 state. 값으로 1을 넣은 이유는 처음에 1개가 기본 있어야 한다.
@@ -36,8 +37,6 @@ function SearchedKeywordLandingPage() {
         lat: 37.49676871972202,
         lng: 127.02474726969814,
     });
-    //  중간 위치 탐색 page 이동 위한 useRouter선언.
-    const router = useRouter();
     //  자식 컴포넌트 props 꺼내서 쓸 수 있도록 한다.
     function checkedPlaceHandler(place) {
         // checkedPlace 객체를 request 폼으로 가공
@@ -61,7 +60,6 @@ function SearchedKeywordLandingPage() {
         //	positions state에 검색된 state값 차곡차곡 담기위한 다중마커state값 (place는 모달창에서 검색 및 선택된 값)
         setCheckedMarkerPlace(place)
     }
-
     //  Input Box 추가 Button Handler
     const addingInputBoxButtonHandler = () => {
         if (inputCount < 4) {
@@ -119,9 +117,9 @@ function SearchedKeywordLandingPage() {
     for (let i = 0; i < inputCount; i++) {
         inputs.push(renderInputArea(i));
     }
-
     //  검색 값 request폼으로 가공 후 서버통신
-    const { mutate, isLoading } = useMutation({
+    const { mutate } = useMutation({
+        queryKey: ['POST_MIDPOINT'],
         mutationFn: async (location) => {
             console.log('location->', location[0]);
             const data = await apis.post
@@ -145,7 +143,6 @@ function SearchedKeywordLandingPage() {
             const lng = data.data.data.lng;
             const newMidPoint = {lat, lng};
             setMidPoint(newMidPoint);
-            console.log("newMidPoint=>",newMidPoint)
         },
     });
     //  중간위치 이동 후 해당 좌표로 지도 이동
@@ -174,6 +171,19 @@ function SearchedKeywordLandingPage() {
             },
         ]);
     }
+        //  중간 위치 탐색 page 이동 위한 useRouter선언.
+        const router = useRouter();
+    const moveToMapMidPointButtonClickHandler = () => {
+        router.push('/mapmidpoint',
+            // { midPoint }
+        );
+    }
+    const queryClient = useQueryClient();
+    const fuckingHell = midPoint
+    queryClient.setQueryData(['FUCK'], fuckingHell);
+    // const { data:midPointProp } = useQuery('midPointProp', () => fetchMidPointData(), {
+    //     initialData: midPoint, // 초기 데이터 설정 (optional)
+    // });
     return (
         <WebWrapper>
         <WebWrapperHeight>
@@ -227,20 +237,12 @@ function SearchedKeywordLandingPage() {
                                 >
                                 검색
                                 </ButtonRedStyle>
-                                {/* <button onClick={moveToMapMidPointButtonClickHandler}>
-                                    중간지점탐색
-                                </button> */}
-                                {/* <MapMidPoint
-                                // onMidPoint={setMidPoint || null}
+                                <button 
                                 onClick={moveToMapMidPointButtonClickHandler}
-                                onMidPoint={moveToMapMidPointButtonClickHandler}
-                                /> */}
-                                <MidPointContext.Provider value={midPoint}>
-                                <MapMidPoint />
-                                </MidPointContext.Provider>
-
-                                
-
+                                >중간지점탐색</button>
+                                {/* <MidPointContext.Provider value={midPoint}>
+                                    <MapMidPoint showVue={false}/>
+                                </MidPointContext.Provider> */}
                         </div>
                 </ContentWrapper>
             </FlexRow>

--- a/src/features/map/MapMidPoint.js
+++ b/src/features/map/MapMidPoint.js
@@ -1,35 +1,38 @@
 import { FlexRow } from '@components/Atoms/Flex'
 import { WebWrapper, WebWrapperHeight } from '@components/Atoms/Wrapper'
-import { MidPointContext } from '@components/Modals/SearchKeywordModalPortal';
+import { MidPointContext, PassPropsWithContextAPI } from '@components/Modals/SearchKeywordModalPortal';
 import { apis } from '@shared/axios';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect, useState } from 'react'
 
 function MapMidPoint() {
-    // const serverUrl = `${process.env.NEXT_PUBLIC_SERVER_KEY}/kakaoApi?query=술집&radius=1500&page=1&size=15`
+    //  MapMidPoint 컴포넌트에 보여지는 요소 안 보이게 하기
+    const [showVue, setShowVue] = useState(false)
+    // console.log("midPoint===>",midPoint);
     // useContext Hook을 사용하여 MidPointContext 컨텍스트 값을 가져온다. (midPoint 값)
-    const midPoint = useContext(MidPointContext);
-    console.log(midPoint);
-    console.log(MidPointContext);
-    const [midPointProp, setMidPointProp] = useState();
-    //  중간 위치 탐색 page 이동 위한 useRouter선언.
-    const router = useRouter();
-    // //  중간 위치 탐색 페이지 이동 버튼 핸들러
-    // const moveToMapMidPointButtonClickHandler = () => {
-    //     router.push('/mapmidpoint');
-    // };
-    const { data, isLoading, isError, refetch } = useQuery({
+    // const midPoint = useContext(MidPointContext);
+    // console.log("midPoint===>",midPoint);
+
+    // midPoint값 props로 받아 state로 저장.
+    // const [midPointProp, setMidPointProp] = useState();
+
+
+    // 서버와 통신
+        const { data, isLoading, isError, refetch } = useQuery({
         queryKey: ['GET_KAKAOAPI'],
         queryFn: async () => {
+        console.log("response",response)
         const response = await apis.get(
             // 서버 URL
-            `/kakaoApi?y=${midPoint.lat}&x=%20${midPoint.lng}&query=술집&radius=1500&page=1&size=15&sort=distance`,
+            `/kakaoApi?y=${midPoint?.lat}&x=%20${midPoint?.lng}&query=술집&radius=1500&page=1&size=15&sort=distance`,
             // 중간지점 lat,lng값
-            midPoint
+            midPointProp
         );
-        return response.data.message;
-    }}, 
+        return response;
+        },
+        staleTime: 6000000 // 100분 (단위: 밀리초)
+    }, 
     {
         // 에러 처리
         onError: (error) => {
@@ -40,20 +43,26 @@ function MapMidPoint() {
             alert(data);
         }
     });
-    const handleClick = () => {
-        refetch()
-        router.push('/mapmidpoint');
-    };
+    // console.log("midPoint===>",midPoint);
+
+
+    // const queryClient = useQueryClient();
+    // // const midPointProp = queryClient.getQueryData('midPointProp');
+    // const { data: midPointProp } = useQuery('midPointProp', () => {
+    //     return fetch('http://http://localhost:3000/map').then((res) => res.json());
+    //   });
+
+    const queryClient = useQueryClient();
+    const midPointProp = queryClient.getQueryData({queryKey: ['FUCK']});
+    console.log("ㅗㅗㅗmidPointPropㅗㅗㅗ",midPointProp)
+    
 
     return (
         <WebWrapper>
             <WebWrapperHeight>
                 <FlexRow style={{ justifyContent: 'space-between' }}>
-                    <button onClick={handleClick}>
-                        검색
-                    </button>
-                    <div></div>
-                    <input></input>
+                {showVue && <button onClick={handleClick}>버튼</button>}
+                {/* <div>{midPointProp}</div> */}
                 </FlexRow>
             </WebWrapperHeight>
         </WebWrapper>
@@ -61,3 +70,41 @@ function MapMidPoint() {
 }
 
 export default MapMidPoint
+
+
+
+
+
+
+
+
+
+
+    // const { data, isLoading, isError, refetch } = useQuery({
+    //     queryKey: ['GET_KAKAOAPI'],
+    //     queryFn: async () => {
+    //     console.log("response",response)
+    //     const response = await apis.get(
+    //         // 서버 URL
+    //         `/kakaoApi?y=${midPoint?.lat}&x=%20${midPoint?.lng}&query=술집&radius=1500&page=1&size=15&sort=distance`,
+    //         // 중간지점 lat,lng값
+    //         midPoint
+    //     );
+    //     return response;
+    //     },
+    //     staleTime: 6000000 // 100분 (단위: 밀리초)
+    // }, 
+    // {
+    //     // 에러 처리
+    //     onError: (error) => {
+    //         console.error(error);
+    //     },
+    //     // 패칭 데이터 상태 변화
+    //     onSettled: (data) => {
+    //         alert(data);
+    //     }
+    // });
+    // useEffect(() => {
+    //     refetch();
+    // }, [router]);
+    // //

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,6 +1538,11 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
+"@remix-run/router@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.5.0.tgz#57618e57942a5f0131374a9fdb0167e25a117fdc"
+  integrity sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
@@ -7721,6 +7726,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.10.0.tgz#090ddc5c84dc41b583ce08468c4007c84245f61f"
+  integrity sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==
+  dependencies:
+    "@remix-run/router" "1.5.0"
+    react-router "6.10.0"
+
+react-router@6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.10.0.tgz#230f824fde9dd0270781b5cb497912de32c0a971"
+  integrity sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==
+  dependencies:
+    "@remix-run/router" "1.5.0"
 
 react-share@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
contextAPI로 props -> react-query로 props전달. 페이지 이동 후에도 props값 휘발되지 않음.
ContextAPI로 props전달은 잘 되지만, 페이지 이동 후에는 props값 휘발됨. 그래서 react-query를 사용하여 props전달. query key로 값 저장하고 불러오는 방식으로 전달. 페이지 이동 후에도 props값 저장 유지.

=> 받아온 값으로 주변 술집 지도 및 리스트로 나타내기