### PR TITLE
유저 경험  바탕 기능 fix

### DIFF
--- a/src/components/Modals/SettingModal.jsx
+++ b/src/components/Modals/SettingModal.jsx
@@ -7,13 +7,19 @@ import styled from 'styled-components';
 import { InputArea } from '@components/Atoms/Input';
 import { ButtonText } from '@components/Atoms/Button';
 import Save from '@features/mypage/Save';
+import { useConfirm } from '../../hook/useConfirm';
+import { FlexRow } from '@components/Atoms/Flex';
 
 export default function SettingModal({ onClose, data }) {
   const router = useRouter();
   // console.log('data', data);
   const [isEditMode, setIsEditMode] = useState('profile');
+
+  const [isNickNameAvailable, setIsNickNameAvailable] = useState(false);
+
   const [password, setPassword] = useState('');
   const changePWInputHandler = (e) => {
+    setIsNickNameAvailable(false);
     const { value, name } = e.target;
     setPassword((pre) => ({ ...pre, [name]: value }));
   };
@@ -31,15 +37,38 @@ export default function SettingModal({ onClose, data }) {
     },
     // onError 콜백 함수 구현
     onError: (error) => {
-      // console.log(error.response);
+      console.log(error.response.status);
+      const status = error.response.status;
       // // 에러 처리
-      alert('중복된 닉네임이 있습니다.');
+      if (status == 415) {
+        alert('입력값을 확인해주세요');
+      } else if (status == 400) {
+        alert('중복확인을 해주세요.');
+      }
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
+      console.log('data', data);
       alert('닉네임 변경이 완료됐습니다.');
+      onClose();
       router.push('/mypage');
     },
   });
+  // 비동기서버통신을 위한 커스텀 훅
+  const [confirm] = useConfirm();
+  const confirmNickName = () => {
+    setIsNickNameAvailable(true);
+    confirm({ type: 'nickName', value: password.nickName }, () => {
+      nickName(password);
+    });
+  };
+
+  const changeNickNameButton = () => {
+    if (!isNickNameAvailable || '') {
+      return alert('중복확인을 해주세요');
+    } else {
+      nickName(password);
+    }
+  };
   //비밀번호 변경
   const { mutate: changePassword } = useMutation({
     mutationFn: async (user) => {
@@ -147,14 +176,27 @@ export default function SettingModal({ onClose, data }) {
               </p>
             </ModeParentsDiv>
             <p>닉네임</p>
-            <InputArea
-              size="lg"
-              variant="default"
-              type="text"
-              name="nickName"
-              value={password.nickName}
-              onChange={changePWInputHandler}
-            />
+            <FlexRow style={{ gap: '20px' }}>
+              <InputArea
+                size="lg"
+                variant="default"
+                type="text"
+                name="nickName"
+                value={password.nickName}
+                onChange={changePWInputHandler}
+              />
+
+              <ButtonText
+                type="button"
+                // size="md"
+                style={{ width: '120px' }}
+                variant="primary"
+                active={true}
+                onClick={confirmNickName}
+                label="중복확인"
+              />
+            </FlexRow>
+
             <p>이메일</p>
             <InputDiv>{data.email}</InputDiv>
 
@@ -163,11 +205,8 @@ export default function SettingModal({ onClose, data }) {
               label="저장하기"
               variant="primary"
               active={true}
-              disabled={isLoading}
-              onClick={() => {
-                nickName(password);
-                onClose();
-              }}
+              // disabled={isLoading || !isNickNameAvailable} // add the `!isNickNameAvailable` condition
+              onClick={changeNickNameButton}
             />
           </InnerDiv>
         ) : isEditMode === 'password' ? (
@@ -205,7 +244,7 @@ export default function SettingModal({ onClose, data }) {
                 환경설정
               </p>
             </ModeParentsDiv>
-            <p>새 비밀번호</p>
+            <p>기존 비밀번호</p>
             <InputArea
               size="lg"
               variant="default"
@@ -471,12 +510,14 @@ const ModeParentsDiv = styled.div`
   font-size: 14px;
   justify-content: center;
   .unModeP {
+    cursor: pointer;
     color: #9ea4aa;
   }
   .modeDiv {
     display: flex;
     align-items: center;
     flex-direction: column;
+    cursor: pointer;
   }
 `;
 const Hr = styled.hr`

--- a/src/components/Modals/SettingPortalExample.jsx
+++ b/src/components/Modals/SettingPortalExample.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import SettingModal from './SettingModal';
+import styled from 'styled-components';
 
 export default function SettingPortalExample({ data }) {
   // console.log('data', data);
@@ -9,11 +10,7 @@ export default function SettingPortalExample({ data }) {
     <>
       <div onClick={() => setShowModal(true)}>
         {' '}
-        <img
-          style={{ width: '20px', height: '20px' }}
-          src="Group 2000.png"
-          alt="유저 설정버튼 입니다."
-        />
+        <Img src="Group 2000.png" alt="유저 설정버튼 입니다." />
       </div>
       {showModal &&
         createPortal(
@@ -23,3 +20,13 @@ export default function SettingPortalExample({ data }) {
     </>
   );
 }
+
+const Img = styled.img`
+  margin-top: 7px;
+  width: 20px;
+  height: 20px;
+  :hover {
+    height: 24px;
+    width: 24px;
+  }
+`;

--- a/src/components/Modals/SignInModal.jsx
+++ b/src/components/Modals/SignInModal.jsx
@@ -116,8 +116,11 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
       alert(error.response.data.message);
     },
     onSuccess: (data) => {
+      setPassword('');
       // console.log('data', data);
-      alert(`${data.data.message}🥹`);
+      alert(
+        `${data.data.message}\n해당 계정의 메일함으로 가서 임시비밀번호를 확인해주세요.`,
+      );
     },
   });
   // validate email format function
@@ -166,7 +169,7 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                 name="email"
                 value={user.email}
                 onChange={changHandler}
-                placeholder="id를 입력하세요"
+                placeholder="이메일을 입력하세요"
               />
               <InputArea
                 className="InputArea"

--- a/src/components/Modals/SignUpModal.jsx
+++ b/src/components/Modals/SignUpModal.jsx
@@ -85,52 +85,58 @@ export default function SignUpModal({ onClose }) {
 
     return isValid;
   };
-
-  const handlePasswordChange = (e) => {
+  const handlePasswordChange1 = (e) => {
     const { name, value } = e.target;
     setUser((pre) => ({ ...pre, [name]: value }));
-
-    if (name === 'checkPassword') {
-      setPasswordError(user.password !== value);
-    }
-
-    if (name === 'password') {
-      const validPassword = validatePassword(value);
-      setPasswordError(!validPassword);
-      setIsValidPassword(validPassword);
-
-      if (user.checkPassword) {
-        setPasswordError(!validPassword || user.checkPassword !== value);
-      }
-    }
 
     if (name === 'checkPassword') {
       setPasswordError(user.password !== value);
       if (user.password) {
         setPasswordError(user.password !== value || !isValidPassword);
       }
+    } else if (name === 'password') {
+      const validPassword = validatePassword(value);
+      setPasswordError(!validPassword);
+      setIsValidPassword(validPassword);
     }
   };
 
+  const handlePasswordChange = (e) => {
+    const { name, value } = e.target;
+    setUser((pre) => ({ ...pre, [name]: value }));
+
+    if (name === 'checkPassword') {
+      setPasswordError(user.password !== value || !isValidPassword);
+    } else if (name === 'password') {
+      const validPassword = validatePassword(value);
+      setPasswordError(!validPassword);
+      setIsValidPassword(validPassword);
+      if (user.checkPassword) {
+        setPasswordError(user.checkPassword !== value || !validPassword);
+      }
+    }
+  };
   //타당성 검사 코드
   const validateForm = (userData) => {
     if (!userData.userName) {
-      alert('이름을 입력해주세요.');
+      alert('성명을 입력해주세요.');
       return false;
     }
-    const userNickName = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/;
+    const userNickName = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,8}$/;
     if (!userNickName.test(userData.nickName)) {
-      alert('닉네임을 입력해주세요.');
-      return false;
-    }
-    if (!validatePassword(userData.password)) {
       alert(
-        '비밀번호는 알파벳 소문자, 대문자, 숫자, 특수문자를 포함한 9~20자여야 합니다.',
+        '닉네임은 영어,숫자,한글로 구성되어야하며 최소 2글자 최대 8글자로 구성되어야합니다.',
       );
       return false;
     }
     if (!validatePassword(userData.password)) {
-      alert('비밀번호 확인을 입력해주세요.');
+      alert(
+        '비밀번호는 알파벳 소문자, 대문자, 숫자, 특수문자를 포함한 8~16자여야 합니다.',
+      );
+      return false;
+    }
+    if (passwordError) {
+      alert('비밀번호 확인을 비밀번호와 맞춰 입력해주세요.');
       return false;
     }
     const userPhoneNumber = /^01([0|1|6|7|8|9]?)([0-9]{3,4})([0-9]{4})$/;
@@ -157,7 +163,7 @@ export default function SignUpModal({ onClose }) {
     if (!user.userName) return false;
     if (!user.nickName) return false;
     if (!validatePassword(user.password)) return false;
-    if (!user.checkPassword) return false;
+    if (passwordError) return false;
 
     return true;
   };
@@ -191,11 +197,12 @@ export default function SignUpModal({ onClose }) {
             value={user.userName}
             placeholder="이름을 입력해주세요."
             onChange={changHandler}
+            maxLength="5"
             required
           />
           <Detaildiv>
             <div className="detailSignUp">닉네임</div>
-            <div className="notice">닉네임 8글자 이내</div>
+            <div className="notice">8자리 이내/영어,한글,숫자로 구성</div>
           </Detaildiv>
           <div style={{ display: 'flex', gap: '20px' }}>
             <InputArea
@@ -206,7 +213,8 @@ export default function SignUpModal({ onClose }) {
               value={user.nickName}
               placeholder="닉네임을 입력해주세요."
               onChange={changHandler}
-              maxLength="16"
+              minLength="2"
+              maxLength="8"
               required
             />
 
@@ -238,7 +246,8 @@ export default function SignUpModal({ onClose }) {
               value={user.password}
               placeholder="비밀번호를 입력해주세요."
               onChange={handlePasswordChange}
-              maxLength="20"
+              minLength="8"
+              maxLength="16"
               required
             />
             {isValidPassword && (
@@ -275,7 +284,9 @@ export default function SignUpModal({ onClose }) {
                   : '#9EA4AA',
               }}
               placeholder="비밀번호를 입력해주세요."
-              onChange={handlePasswordChange}
+              onChange={handlePasswordChange1}
+              minLength="8"
+              maxLength="16"
               required
             />
             {!passwordError && user.password && (
@@ -320,6 +331,7 @@ export default function SignUpModal({ onClose }) {
                 value={user.phoneNumber}
                 placeholder="전화번호를 입력해주세요."
                 onChange={changHandler}
+                maxLength="11"
                 required
               />
               <div className="detailSignUp">이메일</div>
@@ -360,6 +372,7 @@ export default function SignUpModal({ onClose }) {
                 variant="default"
                 name="birth"
                 value={user.birth}
+                maxLength="8"
                 placeholder="생년월일 8글자를 입력해주세요."
                 onChange={changHandler}
               />

--- a/src/components/Molecules/LinkToNav.jsx
+++ b/src/components/Molecules/LinkToNav.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ButtonText } from '@components/Atoms/Button';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { cookies } from '../../shared/cookie';
 import { useRouter } from 'next/router';
 import SignInPotalExample from '@components/Modals/SignInPortalExample';
@@ -20,9 +20,13 @@ export const LinkToNav = () => {
   const router = useRouter();
   const [isLoginMode, setIsLoginMode] = useState(false);
   const [showSubMenu, setShowSubMenu] = useState(false);
+
   //모달창 여닫는 useState
   const [showsignInModal, setShowsignInModal] = useState(false);
   const [showSignUpModal, setShowSignUpModal] = useState(false);
+
+  const token = cookies.get('access_token');
+  const nickName = cookies.get('nick_name');
 
   // 토큰 삭제 함수
   const deleteTokens = () => {
@@ -35,10 +39,9 @@ export const LinkToNav = () => {
     deleteTokens();
     router.push('/');
   };
-  const token = cookies.get('access_token');
-  const refresh_token = cookies.get('refresh_token');
+
   // console.log('access_token', token);
-  // console.log('refresh_token', refresh_token);
+  // console.log('nickName', nickName);
 
   useEffect(() => {
     setIsLoginMode(!!token);
@@ -76,6 +79,20 @@ export const LinkToNav = () => {
       }
     },
   });
+
+  const ref = useRef(null); // nav 태그를 참조하기 위한 useRef
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        setShowSubMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref]);
 
   return (
     <nav style={{ display: 'flex' }}>
@@ -164,14 +181,14 @@ export const LinkToNav = () => {
             className="userNameBT"
             variant="hoverRed"
             onClick={() => setShowSubMenu(!showSubMenu)}
-            label={`${data?.userName}님`}
+            label={`${nickName}님`}
           ></ButtonText>
           {showSubMenu && (
-            <Ullist className="ullist">
+            <Ullist ref={ref} className="ullist">
               <li className="listName">
                 <a
                   onClick={() => setShowSubMenu(!showSubMenu)}
-                >{`${data?.userName}님`}</a>
+                >{`${nickName}님`}</a>
               </li>
               <li className="list">
                 <a

--- a/src/components/Organisms/Footer.jsx
+++ b/src/components/Organisms/Footer.jsx
@@ -31,7 +31,7 @@ export const Footer = () => {
                 리스트
               </Link>
               <Link href="/map" className="aTag">
-                탐색
+                지도 검색
               </Link>
               <Link href="/community" className="aTag">
                 커뮤니티

--- a/src/features/mypage/GetMyAlcohols.js
+++ b/src/features/mypage/GetMyAlcohols.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useRouter } from 'next/router';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { LikeHeartIcon } from '@components/Atoms/HeartIcon';
 
 //페이지네이션 임포트
 import Pagination from '@components/Modals/Pagenation2';
@@ -99,8 +100,12 @@ const GetMyAlcohols = () => {
                   src={post.postList[0].s3Url}
                   alt={post.place_name}
                 />
-                <div>
-                  <p>{post.place_name}</p>
+                <div className="flexGap">
+                  <p className="title">{post.place_name}</p>
+                  <div className="flex">
+                    <LikeHeartIcon />
+                    <p className="likecnt">{post.roomLikecnt}</p>
+                  </div>
                 </div>
               </div>
             </ContainerDiv>
@@ -129,5 +134,20 @@ const ContainerDiv = styled.div`
   .p {
     margin-top: 12px;
     font-size: 16px;
+  }
+  .title {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 24px;
+  }
+  .flexGap {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .flex {
+    display: flex;
+    align-items: center;
+    gap: 10px;
   }
 `;

--- a/src/features/mypage/GetmyPost.js
+++ b/src/features/mypage/GetmyPost.js
@@ -9,6 +9,7 @@ import { useState } from 'react';
 //페이지네이션 임포트
 import Pagination from '@components/Modals/Pagenation2';
 import chunk from '@components/Modals/chunk';
+import { LikeHeartIcon } from '@components/Atoms/HeartIcon';
 
 const GetmyPost = () => {
   const token = cookies.get('access_token');
@@ -25,7 +26,7 @@ const GetmyPost = () => {
           Access_Token: `${token}`,
         },
       });
-      // console.log('dataPost--------------', data.data.posts);
+      console.log('dataPost--------------', data.data.posts);
       return data.data.posts;
     },
   });
@@ -100,7 +101,13 @@ const GetmyPost = () => {
                   src={post.s3Url}
                   alt={post.title}
                 />
-                <p>{post.title}</p>
+                <div className="flexGap">
+                  <p className="title">{post.title}</p>
+                  <div className="flex">
+                    <LikeHeartIcon />
+                    <p className="likecnt">{post.likecnt}</p>
+                  </div>
+                </div>
               </div>
             </ContainerDiv>
           ))}
@@ -128,5 +135,20 @@ const ContainerDiv = styled.div`
   .p {
     margin-top: 12px;
     font-size: 16px;
+  }
+  .title {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 24px;
+  }
+  .flexGap {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .flex {
+    display: flex;
+    align-items: center;
+    gap: 10px;
   }
 `;

--- a/src/features/mypage/MyWritePost.js
+++ b/src/features/mypage/MyWritePost.js
@@ -4,10 +4,11 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import Pagination from '@components/Modals/Pagenation2';
 import chunk from '@components/Modals/chunk';
+import { LikeHeartIcon } from '@components/Atoms/HeartIcon';
 
 const MyWritePost = (data) => {
   const push = useRouter();
-  console.log('mywrutedata', data.data.posts);
+  // console.log('mywrutedata', data.data.posts);
   const myData = data.data.posts;
 
   //페이지 네이션 처음 시작이 1번창부터 켜지도록
@@ -73,7 +74,14 @@ const MyWritePost = (data) => {
                 onerror="this.onerror=null; this.src='Group 2017.png';"
               />
               <div className="innerDiv">
-                <p className="title">{post.title}</p>
+                <div className="flexGap">
+                  <p className="title">{post.title}</p>
+                  <div className="flex">
+                    <LikeHeartIcon />
+                    <p className="title">{post.likecnt}</p>
+                  </div>
+                </div>
+
                 <p className="description">{post.description}</p>
               </div>
             </PostDiv>
@@ -93,7 +101,7 @@ export default MyWritePost;
 
 const ContainerDiv = styled.div`
   display: flex;
-  gap: 24px;
+  gap: 0px 24px;
   flex-wrap: wrap;
 `;
 
@@ -137,5 +145,14 @@ const PostDiv = styled.div`
     word-wrap: break-word;
     overflow-y: hidden;
     height: 30px;
+  }
+  .flexGap {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+  .flex {
+    display: flex;
+    gap: 10px;
   }
 `;

--- a/src/pages/mypage/index.js
+++ b/src/pages/mypage/index.js
@@ -41,7 +41,7 @@ const MyPage = () => {
         <UserDiv key={data?.id}>
           <div className="userSetting">
             <UserNameP>
-              <Span>{data?.userName}</Span>님
+              <Span>{data?.nickName}</Span>님
             </UserNameP>
             <SettingPortalExample data={data} />
           </div>
@@ -53,11 +53,9 @@ const MyPage = () => {
       {settingMyPage === 'log' ? (
         <>
           <WebWrapper>
-            <div
-              style={{ display: 'flex', gap: '40px', alignContent: 'center' }}
-            >
+            <TabButton>
               <p
-                style={{ color: 'red', cursor: 'pointer' }}
+                className="active"
                 onClick={() => {
                   setSettingMyPage('log');
                 }}
@@ -65,7 +63,7 @@ const MyPage = () => {
                 기록
               </p>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('post');
                 }}
@@ -73,14 +71,14 @@ const MyPage = () => {
                 내가 작성한 글 보기
               </p>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('like');
                 }}
               >
                 좋아요
               </p>
-            </div>
+            </TabButton>
           </WebWrapper>
           <BottomDiv>
             <WebWrapper>
@@ -91,15 +89,9 @@ const MyPage = () => {
       ) : settingMyPage === 'post' ? (
         <>
           <WebWrapper>
-            <div
-              style={{
-                display: 'flex',
-                gap: '40px',
-                alignContent: 'center',
-              }}
-            >
+            <TabButton>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('log');
                 }}
@@ -107,7 +99,7 @@ const MyPage = () => {
                 기록
               </p>
               <p
-                style={{ color: 'red', cursor: 'pointer' }}
+                className="active"
                 onClick={() => {
                   setSettingMyPage('post');
                 }}
@@ -115,14 +107,14 @@ const MyPage = () => {
                 내가 작성한 글 보기
               </p>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('like');
                 }}
               >
                 좋아요
               </p>
-            </div>
+            </TabButton>
           </WebWrapper>
 
           <BottomDiv>
@@ -134,15 +126,9 @@ const MyPage = () => {
       ) : settingMyPage === 'like' ? (
         <>
           <WebWrapper>
-            <div
-              style={{
-                display: 'flex',
-                gap: '40px',
-                alignContent: 'center',
-              }}
-            >
+            <TabButton>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('log');
                 }}
@@ -150,7 +136,7 @@ const MyPage = () => {
                 기록
               </p>
               <p
-                style={{ cursor: 'pointer' }}
+                className="wait"
                 onClick={() => {
                   setSettingMyPage('post');
                 }}
@@ -158,14 +144,14 @@ const MyPage = () => {
                 내가 작성한 글 보기
               </p>
               <p
-                style={{ color: 'red', cursor: 'pointer' }}
+                className="active"
                 onClick={() => {
                   setSettingMyPage('like');
                 }}
               >
                 좋아요
               </p>
-            </div>
+            </TabButton>
           </WebWrapper>
           <BottomDiv>
             <WebWrapper>
@@ -176,9 +162,7 @@ const MyPage = () => {
       ) : (
         <>
           <WebWrapper>
-            <div
-              style={{ display: 'flex', gap: '10px', alignContent: 'center' }}
-            >
+            <TabButton>
               <p
                 onClick={() => {
                   setSettingMyPage('log');
@@ -208,7 +192,7 @@ const MyPage = () => {
               >
                 보관함
               </p>
-            </div>
+            </TabButton>
           </WebWrapper>
 
           <BottomDiv>
@@ -223,6 +207,22 @@ const MyPage = () => {
 };
 
 export default MyPage;
+const TabButton = styled.div`
+  display: flex;
+  gap: 40px;
+  align-items: center;
+  .active {
+    color: #ff4840;
+    cursor: pointer;
+    font-size: 15px;
+  }
+  .wait {
+    cursor: pointer;
+    :hover {
+      color: #ff6a64;
+    }
+  }
+`;
 
 const UserDiv = styled.div`
   margin-top: 49px;


### PR DESCRIPTION
1. 로그인 시 모달창에 회원가입 버튼 누르면 바로 회원가입 모달창 뜨게하기 
2. 회원가입 비밀번호 타당성? 맞으면 바로 입력창에 초록 브이 띄워주기 
3. 비밀번호 확인도 마찬가지로
4. 입력값이 타당하지 않으면 회원가입시 다음으로 넘어가지 않도록
5. 비밀번호 찾기로 이메일 보내고 난 후 로그인 창 갔다가 다시 비밀번호 찾기로 오면 이메일 그대로 띄워져 있던 것 빈 값으로 변하게 수정
5. 비밀번호 찾기 시 얼럿 내용 수정
( response + 해당 계정의 메일함으로 가서 임시비밀번호를 확인해주세요.)
6. 네비게이션 바, 마이페이지에  이름 대신 닉네임으로 
7. 네비게이션 바 외부 클릭시 창 닫히도록 
8. 마이페이지에서 볼 수 있는 게시글들 전부 likecount 볼 수 있도록
9. 마이 페이지 탭 하는 부분 액티브 된 부분과 아닌 부분 글씨 크기 차이 및 호버시 색상 + 커서 
10. 설정 버튼 호버시 크기 변환 및 위치 조정 + 설정 모달창 탭에 커서 포인터 
11. 닉네임 변경시 중복확인 버튼 추가
12. 중복확인 아닐 시 저장 못하고, 중복 값 있을 시 진행 안 되게 , 중복값아니지만 중복확인 버튼 안 누르고 저장할 시 중복확인을 해주세요 얼럿 뜨도록 수정
13. 비밀번호 설정에 새 비밀번호 두개 만들어 놓은 것 하나 기존비밀번호 수정
14. 하단 푸터에 탐색 -> 지도 검색으로 변환
