### PR TITLE
347 fix find email

### DIFF
--- a/src/components/Atoms/Input.jsx
+++ b/src/components/Atoms/Input.jsx
@@ -19,7 +19,8 @@ const StyledInput = styled.input`
     color: ${(props) => props.placeColor};
   }
   &:focus {
-    outline: ${(props) => props.focusBorderColor};
+    //focus시 컬러 변화가 없어 outline에서 border-color로 바꿨습니다 (서윤)
+    border-color: ${(props) => props.focusBorderColor};
     ::placeholder {
       color: transparent;
     }
@@ -81,6 +82,14 @@ export const InputArea = ({
       borderColor = LightTheme.GRAY_400;
       focusBackgroundColor = LightTheme.WHITE;
       focusBorderColor = LightTheme.GRAY_200;
+      placeColor = LightTheme.BLACK;
+      break;
+    case 'defaultWithActive':
+      backgroundColor = LightTheme.WHITE;
+      fontColor = LightTheme.GRAY_200;
+      borderColor = LightTheme.GRAY_400;
+      focusBackgroundColor = LightTheme.BG_COLOR_DARK;
+      focusBorderColor = LightTheme.STATUS_POSITIVE;
       placeColor = LightTheme.BLACK;
       break;
     case 'primary':

--- a/src/components/Modals/SettingModal.jsx
+++ b/src/components/Modals/SettingModal.jsx
@@ -184,6 +184,9 @@ export default function SettingModal({ onClose, data }) {
                 name="nickName"
                 value={password.nickName}
                 onChange={changePWInputHandler}
+                onKeyDown={(e) => {
+                  if (e.key === ' ') e.preventDefault();
+                }}
               />
 
               <ButtonText
@@ -255,6 +258,9 @@ export default function SettingModal({ onClose, data }) {
               onChange={handlePasswordChange}
               maxLength="20"
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
             <p>새 비밀번호</p>
             <InputArea
@@ -267,6 +273,9 @@ export default function SettingModal({ onClose, data }) {
               onChange={handlePasswordChange}
               maxLength="20"
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
             <p>비밀번호 확인</p>
             <InputArea
@@ -278,6 +287,9 @@ export default function SettingModal({ onClose, data }) {
               placeholder="비밀번호를 확인해주세요."
               onChange={handlePasswordChange}
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
             {passwordError && (
               <p style={{ color: 'red', fontSize: '12px', marginTop: '-5px' }}>

--- a/src/components/Modals/SignInModal.jsx
+++ b/src/components/Modals/SignInModal.jsx
@@ -242,6 +242,7 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                   value={email.userName}
                   onChange={emailchangeHandler}
                   placeholder="이름를 입력하세요"
+                  maxLength="5"
                 />
                 {findEmailSuccess && (
                   <img
@@ -262,7 +263,7 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                 <InputArea
                   style={{
                     marginTop: '-15px',
-                    borderColor: emailFormatError
+                    borderColor: findEmailError
                       ? '#EF2B2A'
                       : findEmailSuccess
                       ? '#3DC061'
@@ -275,6 +276,7 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                   value={email.phoneNumber}
                   onChange={emailchangeHandler}
                   placeholder="전화번호를 입력하세요"
+                  maxLength="11"
                 />
                 {findEmailSuccess && (
                   <img
@@ -315,7 +317,11 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                   active={true}
                   onClick={() => {
                     setIsEditMode('login');
-                    setEmail('');
+                    setEmail({
+                      userName: '',
+                      phoneNumber: '',
+                    });
+
                     setFindEmailSuccess(''); // 확인 상태로 돌아가도록 합니다.
                   }}
                 />
@@ -325,13 +331,13 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                     marginBottom: '50px',
                     marginTop: '50px',
                   }}
-                  최
                   label="확인"
                   size="md"
                   variant="primary"
                   active={true}
                   onClick={() => {
                     findMyEmail(email);
+                    setFindEmailError(false);
                   }}
                 />
               )}

--- a/src/components/Modals/SignInModal.jsx
+++ b/src/components/Modals/SignInModal.jsx
@@ -165,21 +165,27 @@ export default function SignInModal({ onClose, setShowSignUpModal }) {
                 className="InputArea"
                 type="text"
                 size="lg"
-                variant="default"
+                variant="defaultWithActive"
                 name="email"
                 value={user.email}
                 onChange={changHandler}
                 placeholder="이메일을 입력하세요"
+                onKeyDown={(e) => {
+                  if (e.key === ' ') e.preventDefault();
+                }}
               />
               <InputArea
                 className="InputArea"
                 size="lg"
-                variant="default"
+                variant="defaultWithActive"
                 type="password"
                 name="password"
                 value={user.password}
                 onChange={changHandler}
                 placeholder="비밀번호를 입력하세요"
+                onKeyDown={(e) => {
+                  if (e.key === ' ') e.preventDefault();
+                }}
               />
               <ButtonText
                 style={{ marginTop: '30px' }}

--- a/src/components/Modals/SignUpModal.jsx
+++ b/src/components/Modals/SignUpModal.jsx
@@ -7,6 +7,7 @@ import { HeadInfo } from '@components/Atoms/SEO/HeadInfo';
 import { ButtonText } from '@components/Atoms/Button';
 import { InputArea } from '@components/Atoms/Input';
 import { useConfirm } from '../../hook/useConfirm';
+import { LightTheme } from '@components/Themes/theme';
 
 export default function SignUpModal({ onClose }) {
   const router = useRouter();
@@ -38,15 +39,6 @@ export default function SignUpModal({ onClose }) {
     setUser((pre) => ({ ...pre, [name]: value }));
   };
   const [passwordError, setPasswordError] = useState(false);
-
-  // const handlePasswordChange = (e) => {
-  //   const { name, value } = e.target;
-  //   setUser((pre) => ({ ...pre, [name]: value }));
-
-  //   if (name === 'checkPassword') {
-  //     setPasswordError(user.password !== value);
-  //   }
-  // };
 
   // passwordCheck 빼고 나머지 라는 뜻
   //3번째 옵션 config
@@ -85,21 +77,6 @@ export default function SignUpModal({ onClose }) {
 
     return isValid;
   };
-  const handlePasswordChange1 = (e) => {
-    const { name, value } = e.target;
-    setUser((pre) => ({ ...pre, [name]: value }));
-
-    if (name === 'checkPassword') {
-      setPasswordError(user.password !== value);
-      if (user.password) {
-        setPasswordError(user.password !== value || !isValidPassword);
-      }
-    } else if (name === 'password') {
-      const validPassword = validatePassword(value);
-      setPasswordError(!validPassword);
-      setIsValidPassword(validPassword);
-    }
-  };
 
   const handlePasswordChange = (e) => {
     const { name, value } = e.target;
@@ -116,6 +93,21 @@ export default function SignUpModal({ onClose }) {
       }
     }
   };
+  const handleCheckPasswordChange = (e) => {
+    const { name, value } = e.target;
+    setUser((pre) => ({ ...pre, [name]: value }));
+    if (name === 'checkPassword') {
+      setPasswordError(user.password !== value);
+      if (user.password) {
+        setPasswordError(user.password !== value || !isValidPassword);
+      }
+    } else if (name === 'password') {
+      const validPassword = validatePassword(value);
+      setPasswordError(!validPassword);
+      setIsValidPassword(validPassword);
+    }
+  };
+
   //타당성 검사 코드
   const validateForm = (userData) => {
     if (!userData.userName) {
@@ -199,6 +191,9 @@ export default function SignUpModal({ onClose }) {
             onChange={changHandler}
             maxLength="5"
             required
+            onKeyDown={(e) => {
+              if (e.key === ' ') e.preventDefault();
+            }}
           />
           <Detaildiv>
             <div className="detailSignUp">닉네임</div>
@@ -206,6 +201,7 @@ export default function SignUpModal({ onClose }) {
           </Detaildiv>
           <div style={{ display: 'flex', gap: '20px' }}>
             <InputArea
+              variant="default"
               size="lg"
               style={{ width: '100%' }}
               type="text"
@@ -216,6 +212,9 @@ export default function SignUpModal({ onClose }) {
               minLength="2"
               maxLength="8"
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
 
             <ButtonText
@@ -237,7 +236,9 @@ export default function SignUpModal({ onClose }) {
           <div style={{ position: 'relative' }}>
             <InputArea
               style={{
-                borderColor: isValidPassword ? '#3DC061' : '#9EA4AA',
+                borderColor: isValidPassword
+                  ? LightTheme.STATUS_POSITIVE
+                  : LightTheme.GRAY_200,
               }}
               type="password"
               name="password"
@@ -249,6 +250,9 @@ export default function SignUpModal({ onClose }) {
               minLength="8"
               maxLength="16"
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
             {isValidPassword && (
               <img
@@ -279,42 +283,52 @@ export default function SignUpModal({ onClose }) {
               style={{
                 borderColor: passwordError
                   ? 'red'
-                  : !passwordError && user.password
-                  ? '#3DC061'
-                  : '#9EA4AA',
+                  : !passwordError &&
+                    user.checkPassword &&
+                    user.password === user.checkPassword
+                  ? LightTheme.STATUS_POSITIVE
+                  : LightTheme.GRAY_200,
               }}
               placeholder="비밀번호를 입력해주세요."
-              onChange={handlePasswordChange1}
+              onChange={handleCheckPasswordChange}
               minLength="8"
               maxLength="16"
               required
+              onKeyDown={(e) => {
+                if (e.key === ' ') e.preventDefault();
+              }}
             />
-            {!passwordError && user.password && (
-              <img
-                src="Group 2066.png"
-                alt="Valid password"
-                style={{
-                  position: 'absolute',
-                  top: '12px',
-                  right: '12px',
-                  width: '20px',
-                  height: '20px',
-                }}
-              />
-            )}
+            {!passwordError &&
+              user.checkPassword &&
+              user.password === user.checkPassword && (
+                <img
+                  src="Group 2066.png"
+                  alt="Valid password"
+                  style={{
+                    position: 'absolute',
+                    top: '12px',
+                    right: '12px',
+                    width: '20px',
+                    height: '20px',
+                  }}
+                />
+              )}
           </div>
 
-          {passwordError && (
+          {passwordError ? (
             <p style={{ color: 'red', fontSize: '12px', marginTop: '-5px' }}>
               비밀번호가 일치하지 않습니다.
             </p>
-          )}
-          {!passwordError && user.password && (
+          ) : !passwordError &&
+            user.checkPassword &&
+            user.password === user.checkPassword ? (
             <p
               style={{ color: '#3DC061', fontSize: '12px', marginTop: '-5px' }}
             >
               비밀번호가 일치합니다.
             </p>
+          ) : (
+            <></>
           )}
           {next ? (
             <>
@@ -333,6 +347,9 @@ export default function SignUpModal({ onClose }) {
                 onChange={changHandler}
                 maxLength="11"
                 required
+                onKeyDown={(e) => {
+                  if (e.key === ' ') e.preventDefault();
+                }}
               />
               <div className="detailSignUp">이메일</div>
 
@@ -351,6 +368,9 @@ export default function SignUpModal({ onClose }) {
                   placeholder="이메일을 입력해주세요."
                   onChange={changHandler}
                   required
+                  onKeyDown={(e) => {
+                    if (e.key === ' ') e.preventDefault();
+                  }}
                 />
                 <ButtonText
                   type="button"
@@ -375,6 +395,9 @@ export default function SignUpModal({ onClose }) {
                 maxLength="8"
                 placeholder="생년월일 8글자를 입력해주세요."
                 onChange={changHandler}
+                onKeyDown={(e) => {
+                  if (e.key === ' ') e.preventDefault();
+                }}
               />
               <ButtonText
                 size="md"

--- a/src/features/AddReComment.js
+++ b/src/features/AddReComment.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { apis } from '@shared/axios';
 import { cookies } from '@shared/cookie';
 import styled from 'styled-components';
+import { LightTheme } from '@components/Themes/theme';
 
 const AddReComment = (comment) => {
   const [reComments, setReComments] = useState(false);
@@ -32,6 +33,7 @@ const AddReComment = (comment) => {
       );
     },
     onSuccess: () => {
+      setReCommentList('');
       alert('댓글 추가를 완료하였습니다.');
     },
     onError: (error) => {
@@ -41,10 +43,10 @@ const AddReComment = (comment) => {
   });
 
   return (
-    <div>
+    <Recomments>
       {reComments ? (
-        <div>
-          <input
+        <div className="Editmode">
+          <Input
             type="text"
             placeholder="답글 입력"
             name="content"
@@ -69,14 +71,21 @@ const AddReComment = (comment) => {
             setReComments(true);
           }}
         >
-          답글달기
+          답글 달기
         </Button>
       )}
-    </div>
+    </Recomments>
   );
 };
 
 export default AddReComment;
+const Recomments = styled.div`
+  display: flex;
+  gap: 20px;
+  .Editmode {
+    display: flex;
+  }
+`;
 
 const Button = styled.button`
   border: none;
@@ -84,6 +93,17 @@ const Button = styled.button`
   font-weight: 400;
   font-size: 12px;
   line-height: 16px;
-  color: #72787f;
+  color: ${LightTheme.GRAY_400};
   width: 60px;
+  cursor: pointer;
+  :hover {
+    color: ${LightTheme.GRAY_800};
+  }
+`;
+const Input = styled.input`
+  font-size: 12px;
+  width: 550px;
+  ::placeholder {
+    color: ${LightTheme.GRAY_200};
+  }
 `;

--- a/src/features/CommentsList.js
+++ b/src/features/CommentsList.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { InputArea } from '@components/Atoms/Input';
 import AddReComment from './AddReComment';
 import ReCommentList from './ReCommentList';
+import { LightTheme } from '@components/Themes/theme';
 
 const CommentsList = () => {
   const queryClient = useQueryClient();
@@ -20,7 +21,7 @@ const CommentsList = () => {
   const [userNickName, setUserNickName] = useState('');
 
   useEffect(() => {
-    const nick_name = localStorage.getItem('nick_name');
+    const nick_name = cookies.get('nick_name');
     setUserNickName(nick_name);
   }, []);
 
@@ -119,23 +120,24 @@ const CommentsList = () => {
                 <div className="nickName">{comment.nickName}</div>
                 <h2 className="content">{comment.content}</h2>
                 <div className="mycomment">
-                  <AddReComment comment={comment} />
                   {userNickName === comment.nickName && (
                     <>
                       <button
                         className="Button"
                         onClick={() => handleEdit(comment)}
                       >
-                        수정
+                        수정하기
                       </button>
                       <button
                         className="Button"
                         onClick={() => handleDelete(comment.id)}
                       >
-                        삭제
+                        삭제하기
                       </button>
                     </>
                   )}
+
+                  <AddReComment comment={comment} />
                 </div>
 
                 <div>
@@ -169,14 +171,21 @@ const CommentDiv = styled.div`
     font-size: 12px;
     line-height: 16px;
   }
+  .mycomment {
+    width: 100%;
+  }
   .Button {
     border: none;
     background-color: transparent;
-    font-weight: 400;
+    font-weight: ${LightTheme.FONT_REGULAR};
     font-size: 12px;
     line-height: 16px;
-    color: #72787f;
-    width: 50px;
+    color: ${LightTheme.GRAY_400};
+    width: 60px;
+    cursor: pointer;
+  }
+  .Button:hover {
+    color: ${LightTheme.GRAY_800};
   }
   .mycomment {
     display: flex;

--- a/src/features/ReCommentList.js
+++ b/src/features/ReCommentList.js
@@ -6,6 +6,7 @@ import { InputArea } from '@components/Atoms/Input';
 import { apis } from '@shared/axios';
 import styled from 'styled-components';
 import AddReComment from './AddReComment';
+import { LightTheme } from '@components/Themes/theme';
 
 const ReCommentList = ({ comment }) => {
   // console.log('comment', comment.commentList);
@@ -17,7 +18,7 @@ const ReCommentList = ({ comment }) => {
   const [userNickName, setUserNickName] = useState('');
 
   useEffect(() => {
-    const nick_name = localStorage.getItem('nick_name');
+    const nick_name = cookies.get('nick_name');
     setUserNickName(nick_name);
   }, []);
 
@@ -106,13 +107,13 @@ const ReCommentList = ({ comment }) => {
                       className="Button"
                       onClick={() => handleEdit(comment)}
                     >
-                      수정
+                      수정하기
                     </button>
                     <button
                       className="Button"
                       onClick={() => handleDelete(comment.id)}
                     >
-                      삭제
+                      삭제하기
                     </button>
                   </>
                 )}
@@ -135,22 +136,22 @@ const CommentDiv = styled.div`
   gap: 10px;
   padding: 20px;
   .nickName {
-    font-weight: 700;
+    font-weight: ${LightTheme.FONT_BOLD};
     font-size: 12px;
     line-height: 16px;
   }
   .content {
-    font-weight: 400;
-    font-size: 12px;
+    font-weight: ${LightTheme.FONT_REGULAR};
+    font-size: 14px;
     line-height: 16px;
   }
   .Button {
     border: none;
     background-color: transparent;
-    font-weight: 400;
-    font-size: 12px;
+    font-weight: ${LightTheme.FONT_REGULAR};
+    font-size: 10px;
     line-height: 16px;
-    color: #72787f;
+    color: ${LightTheme.GRAY_500};
     width: 50px;
   }
 `;

--- a/src/features/mypage/EventForm.js
+++ b/src/features/mypage/EventForm.js
@@ -1,45 +1,61 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import moment from 'moment/moment';
+import { LightTheme } from '@components/Themes/theme';
 
 const EventForm = ({ selectedDate, selectedDateLog, onSubmit }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [titleLength, setTitleLength] = useState(0);
+  const [contentLength, setContentLength] = useState(0);
 
   const handleTitleChange = (e) => {
     setTitle(e.target.value);
+    setTitleLength(e.target.value.length);
   };
 
   const handleContentChange = (e) => {
     setContent(e.target.value);
+    setContentLength(e.target.value.length);
   };
-
   const handleSubmit = (e) => {
     e.preventDefault();
     onSubmit({ title, content, selectedDate });
     setTitle('');
     setContent('');
+    setContentLength(0);
   };
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Input
-        type="text"
-        value={title}
-        placeholder="제목을 작성해주세요."
-        onChange={handleTitleChange}
-        required
-      />
+      <div className="bottomContent">
+        <Input
+          type="text"
+          value={title}
+          maxLength="49"
+          placeholder="제목을 작성해주세요."
+          onChange={handleTitleChange}
+          required
+        />
+        <CharCount>{titleLength} / 50</CharCount>
+      </div>
+
       <Hr />
 
       <Textarea
         value={content}
         placeholder="내용을 입력해주세요."
+        maxLength="1499"
         onChange={handleContentChange}
         required
       />
+
       <div className="bottomContent">
-        <p className="date">{selectedDateLog}</p>
+        <div className="bottomContent2">
+          <p className="date">{selectedDateLog}</p>
+          <CharCount>{contentLength} / 1500</CharCount>
+        </div>
+
         <Button type="submit">작성</Button>
       </div>
     </Form>
@@ -56,16 +72,21 @@ const Form = styled.form`
   border-radius: 8px;
   padding: 15px;
   .bottomContent {
+    width: 100%;
     display: flex;
-    align-items: center;
     justify-content: space-between;
   }
+  .bottomContent2 {
+    display: flex;
+    align-items: center;
+    gap: 270px;
+  }
   .date {
-    color: #9ea4aa;
+    color: ${LightTheme.FONT_SECONDARY};
   }
 `;
 const Hr = styled.hr`
-  border: 0.5px solid#E8EBED;
+  border: 0.5px solid ${LightTheme.FONT_TERTIARY};
   width: 447px;
   height: 0px;
 `;
@@ -77,7 +98,7 @@ const Input = styled.input`
   padding: 8px;
   border: none;
   ::placeholder {
-    color: #9ea4aa;
+    color: ${LightTheme.FONT_SECONDARY};
   }
 `;
 
@@ -87,8 +108,14 @@ const Textarea = styled.textarea`
   border: none;
   height: 207px;
   ::placeholder {
-    color: #9ea4aa;
+    color: ${LightTheme.FONT_SECONDARY};
   }
+`;
+const CharCount = styled.p`
+  font-size: 12px;
+  color: #9ea4aa;
+  margin-top: 13px;
+  width: 65px;
 `;
 
 const Button = styled.button`
@@ -101,7 +128,7 @@ const Button = styled.button`
   margin-top: 10px;
   cursor: pointer;
   &:hover {
-    background-color: #c8150d;
+    background-color: ${LightTheme.PRIMARY_HEAVY};
   }
 `;
 

--- a/src/features/mypage/GetMyAlcohols.js
+++ b/src/features/mypage/GetMyAlcohols.js
@@ -76,41 +76,44 @@ const GetMyAlcohols = () => {
   } else {
     return (
       <div>
-        <div
-          style={{
-            display: 'flex',
-            gap: '24px',
-            flexWrap: 'wrap',
-          }}
-        >
-          {currentPageData.map((post) => (
-            <ContainerDiv key={post.apiId}>
-              <div
-                onClick={() => {
-                  push.push(`/alcohols/${post.apiId}`);
-                }}
-              >
-                <img
-                  style={{
-                    width: '384px',
-                    height: '242px',
-                    objectFit: 'cover',
-                    borderRadius: '12px',
+        <LogBox>
+          <div
+            style={{
+              display: 'flex',
+              gap: '24px',
+              flexWrap: 'wrap',
+            }}
+          >
+            {currentPageData.map((post) => (
+              <ContainerDiv key={post.apiId}>
+                <div
+                  onClick={() => {
+                    push.push(`/alcohols/${post.apiId}`);
                   }}
-                  src={post.postList[0].s3Url}
-                  alt={post.place_name}
-                />
-                <div className="flexGap">
-                  <p className="title">{post.place_name}</p>
-                  <div className="flex">
-                    <LikeHeartIcon />
-                    <p className="likecnt">{post.roomLikecnt}</p>
+                >
+                  <img
+                    style={{
+                      width: '384px',
+                      height: '242px',
+                      objectFit: 'cover',
+                      borderRadius: '12px',
+                    }}
+                    src={post.postList[0]?.s3Url || 'noimage_282x200____.png'}
+                    alt={post.place_name}
+                  />
+                  <div className="flexGap">
+                    <p className="title">{post.place_name}</p>
+                    <div className="flex">
+                      <LikeHeartIcon />
+                      <p className="likecnt">{post.roomLikecnt}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </ContainerDiv>
-          ))}
-        </div>
+              </ContainerDiv>
+            ))}
+          </div>
+        </LogBox>
+
         <Pagination
           pages={chunkedData.map((_, i) => i + 1)}
           activePage={activePage}
@@ -122,6 +125,12 @@ const GetMyAlcohols = () => {
 };
 
 export default GetMyAlcohols;
+
+const LogBox = styled.div`
+  /* border: 1px solid black; */
+  width: 1210px;
+  height: 960px;
+`;
 
 const ContainerDiv = styled.div`
   display: flex;

--- a/src/features/mypage/GetmyPost.js
+++ b/src/features/mypage/GetmyPost.js
@@ -77,41 +77,44 @@ const GetmyPost = () => {
   } else {
     return (
       <div>
-        <div
-          style={{
-            display: 'flex',
-            gap: '24px',
-            flexWrap: 'wrap',
-          }}
-        >
-          {currentPageData.map((post) => (
-            <ContainerDiv key={post.id}>
-              <div
-                onClick={() => {
-                  push.push(`/community/${post.id}`);
-                }}
-              >
-                <img
-                  style={{
-                    width: '384px',
-                    height: '242px',
-                    objectFit: 'cover',
-                    borderRadius: '12px',
+        <LogBox>
+          <div
+            style={{
+              display: 'flex',
+              gap: '24px',
+              flexWrap: 'wrap',
+            }}
+          >
+            {currentPageData.map((post) => (
+              <ContainerDiv key={post.id}>
+                <div
+                  onClick={() => {
+                    push.push(`/community/${post.id}`);
                   }}
-                  src={post.s3Url}
-                  alt={post.title}
-                />
-                <div className="flexGap">
-                  <p className="title">{post.title}</p>
-                  <div className="flex">
-                    <LikeHeartIcon />
-                    <p className="likecnt">{post.likecnt}</p>
+                >
+                  <img
+                    style={{
+                      width: '384px',
+                      height: '242px',
+                      objectFit: 'cover',
+                      borderRadius: '12px',
+                    }}
+                    src={post.s3Url || 'noimage_282x200____.png'}
+                    alt={post.title}
+                  />
+                  <div className="flexGap">
+                    <p className="title">{post.title}</p>
+                    <div className="flex">
+                      <LikeHeartIcon />
+                      <p className="likecnt">{post.likecnt}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </ContainerDiv>
-          ))}
-        </div>
+              </ContainerDiv>
+            ))}
+          </div>
+        </LogBox>
+
         <Pagination
           pages={chunkedData.map((_, i) => i + 1)}
           activePage={activePage}
@@ -123,6 +126,12 @@ const GetmyPost = () => {
 };
 
 export default GetmyPost;
+
+const LogBox = styled.div`
+  /* border: 1px solid black; */
+  width: 1210px;
+  height: 960px;
+`;
 
 const ContainerDiv = styled.div`
   display: flex;

--- a/src/features/mypage/Log.js
+++ b/src/features/mypage/Log.js
@@ -72,7 +72,7 @@ function Log() {
           Access_Token: `${token}`,
         },
       });
-      // console.log('result~~~', data.data);
+      //console.log('result~~~', data.data);
       return data.data.data;
     },
     onSuccess: (data) => {
@@ -91,6 +91,7 @@ function Log() {
   // 츄가
   const { mutate } = useMutation({
     mutationFn: async (event) => {
+      // console.log('event', event);
       const data = await apis.post('my-page/calendar', event, {
         headers: {
           Access_Token: `${token}`,
@@ -122,7 +123,7 @@ function Log() {
   //수정
   const { mutate: calLogUpdate } = useMutation({
     mutationFn: async ({ id, payload }) => {
-      // console.log('patloadEdit', payload);
+      console.log('patloadEdit', payload);
       const { data } = await apis.patch(`/my-page/calendar/${id}`, payload, {
         headers: {
           Access_Token: `${token}`,
@@ -133,11 +134,10 @@ function Log() {
     },
     onSuccess: () => {
       setIsEditMode(false);
-
       queryClient.invalidateQueries(['LOG_DATE']);
       window.alert('수정 완료!');
     },
-    onError: () => {
+    onError: (e) => {
       window.alert('수정 오류!');
     },
   });
@@ -270,7 +270,7 @@ function Log() {
           </Div>
           <ReviewDiv>
             <h1 className="title">기록</h1>
-            <div>
+            <LogBox>
               {currentPageData.map((calLog) => (
                 <CalLogDiv key={calLog.id}>
                   {isEditMode[calLog.id] ? (
@@ -283,6 +283,7 @@ function Log() {
                             size="md"
                             type="text"
                             name="title"
+                            maxLength="50"
                             value={callederTitle}
                             onChange={(e) => setCallenderTitle(e.target.value)}
                           />
@@ -292,6 +293,7 @@ function Log() {
                             size="md"
                             type="date"
                             name="content"
+                            maxLength="1500"
                             value={callederSetDated}
                             onChange={(e) =>
                               setCallenderSetDated(e.target.value)
@@ -342,7 +344,7 @@ function Log() {
                   )}
                 </CalLogDiv>
               ))}
-            </div>
+            </LogBox>
             <Pagination
               pages={chunkedData.map((_, i) => i + 1)}
               activePage={activePage}
@@ -356,10 +358,14 @@ function Log() {
 }
 
 export default Log;
+const LogBox = styled.div`
+  /* border: 1px solid black; */
+  width: fit-content;
+  height: 560px;
+`;
 
 const ReviewDiv = styled.div`
   width: 688px;
-
   display: flex;
   flex-direction: column;
   .p {
@@ -480,6 +486,8 @@ const CalLogDiv = styled.div`
   .textarea {
     margin-top: 5px;
     border: none;
+    height: 100%;
+    width: 100%;
   }
   .del {
     padding: 3px 12px;

--- a/src/features/mypage/MyWritePost.js
+++ b/src/features/mypage/MyWritePost.js
@@ -58,41 +58,43 @@ const MyWritePost = (data) => {
     );
   } else {
     return (
-      <div>
-        <ContainerDiv>
-          {currentPageData.map((post) => (
-            <PostDiv
-              key={post.id}
-              onClick={() => {
-                push.push(`/community/${post.id}`);
-              }}
-            >
-              <img
-                className="image"
-                src={post.s3Url}
-                alt={post.title}
-                onerror="this.onerror=null; this.src='Group 2017.png';"
-              />
-              <div className="innerDiv">
-                <div className="flexGap">
-                  <p className="title">{post.title}</p>
-                  <div className="flex">
-                    <LikeHeartIcon />
-                    <p className="title">{post.likecnt}</p>
+      <>
+        <LogBox>
+          <ContainerDiv>
+            {currentPageData.map((post) => (
+              <PostDiv
+                key={post.id}
+                onClick={() => {
+                  push.push(`/community/${post.id}`);
+                }}
+              >
+                <img
+                  className="image"
+                  src={post.s3Url}
+                  alt={post.title}
+                  onerror="this.onerror=null; this.src='Group 2017.png';"
+                />
+                <div className="innerDiv">
+                  <div className="flexGap">
+                    <p className="title">{post.title}</p>
+                    <div className="flex">
+                      <LikeHeartIcon />
+                      <p className="title">{post.likecnt}</p>
+                    </div>
                   </div>
-                </div>
 
-                <p className="description">{post.description}</p>
-              </div>
-            </PostDiv>
-          ))}
-        </ContainerDiv>
+                  <p className="description">{post.description}</p>
+                </div>
+              </PostDiv>
+            ))}
+          </ContainerDiv>
+        </LogBox>
         <Pagination
           pages={chunkedData.map((_, i) => i + 1)}
           activePage={activePage}
           setPage={setActivePage}
         />
-      </div>
+      </>
     );
   }
 };
@@ -103,6 +105,11 @@ const ContainerDiv = styled.div`
   display: flex;
   gap: 0px 24px;
   flex-wrap: wrap;
+`;
+const LogBox = styled.div`
+  /* border: 1px solid black; */
+  width: 1250px;
+  height: 860px;
 `;
 
 const PostDiv = styled.div`

--- a/src/pages/OAuth/index.js
+++ b/src/pages/OAuth/index.js
@@ -7,6 +7,7 @@ import { cookies } from '@shared/cookie';
 import styled from 'styled-components';
 import { InputArea } from '@components/Atoms/Input';
 import { ButtonText } from '@components/Atoms/Button';
+import { LightTheme } from '@components/Themes/theme';
 
 import { toast } from 'react-toastify';
 const OAuth = (Toast) => {
@@ -53,9 +54,32 @@ const OAuth = (Toast) => {
     setPassword((pre) => ({ ...pre, [name]: value }));
 
     if (name === 'checkPassword') {
-      setPasswordError(password.password !== value);
+      setPasswordError(password.password !== value || !isValidPassword);
+    } else if (name === 'password') {
+      const validPassword = validatePassword(value);
+      setPasswordError(!validPassword);
+      setIsValidPassword(validPassword);
+      if (password.checkPassword) {
+        setPasswordError(password.checkPassword !== value || !validPassword);
+      }
     }
   };
+  const handleCheckPasswordChange = (e) => {
+    const { name, value } = e.target;
+    setPassword((pre) => ({ ...pre, [name]: value }));
+    if (name === 'checkPassword') {
+      setPasswordError(password.password !== value);
+      if (password.password) {
+        setPasswordError(password.password !== value || !isValidPassword);
+      }
+    } else if (name === 'password') {
+      const validPassword = validatePassword(value);
+      setPasswordError(!validPassword);
+      setIsValidPassword(validPassword);
+    }
+  };
+  // 유효성 검사 후, 이미지를 띄우기 위한 state 추가
+  const [isValidPassword, setIsValidPassword] = useState(false);
 
   //비밀번호 조건
   const validatePassword = (password) => {
@@ -64,11 +88,15 @@ const OAuth = (Toast) => {
     const regex =
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_])[A-Za-z\d\W_]{9,20}$/;
 
-    return (
+    const isValid =
       password.length >= minLength &&
       password.length <= maxLength &&
-      regex.test(password)
-    );
+      regex.test(password);
+
+    // 유효성 검사 후, 상태 업데이트
+    setIsValidPassword(isValid);
+
+    return isValid;
   };
   const validateForm = (userData) => {
     if (!validatePassword(userData.password)) {
@@ -100,6 +128,9 @@ const OAuth = (Toast) => {
           onChange={handlePasswordChange}
           maxLength="20"
           required
+          onKeyDown={(e) => {
+            if (e.key === ' ') e.preventDefault();
+          }}
         />
         <div
           style={{
@@ -110,38 +141,109 @@ const OAuth = (Toast) => {
           <p className="pw">새 비밀번호</p>
           <p className="pwnt">8~16 자리 / 영문 대소문자, 숫자, 특수문자 포함</p>
         </div>
-
-        <InputArea
-          size="lg"
-          variant="default"
-          type="password"
-          name="password"
-          placeholder="변경할 비밀번호를 입력해주세요."
-          value={password.password}
-          onChange={handlePasswordChange}
-          maxLength="20"
-          required
-        />
+        <div style={{ position: 'relative' }}>
+          <InputArea
+            size="lg"
+            variant="default"
+            type="password"
+            name="password"
+            placeholder="변경할 비밀번호를 입력해주세요."
+            value={password.password}
+            onChange={handlePasswordChange}
+            minLength="8"
+            maxLength="16"
+            required
+            onKeyDown={(e) => {
+              if (e.key === ' ') e.preventDefault();
+            }}
+            style={{
+              borderColor: isValidPassword
+                ? LightTheme.STATUS_POSITIVE
+                : LightTheme.GRAY_400,
+            }}
+          />
+          {isValidPassword && (
+            <img
+              src="Group 2066.png"
+              alt="Valid password"
+              style={{
+                position: 'absolute',
+                top: '12px',
+                right: '12px',
+                width: '20px',
+                height: '20px',
+              }}
+            />
+          )}
+        </div>
         <p className="pw">비밀번호 확인</p>
-        <InputArea
-          size="lg"
-          variant="default"
-          type="password"
-          name="checkPassword"
-          value={password.checkPassword}
-          placeholder="비밀번호를 확인해주세요."
-          onChange={handlePasswordChange}
-          required
-        />
-        {passwordError && (
-          <p style={{ color: 'red', fontSize: '12px' }}>
+        <div style={{ position: 'relative' }}>
+          <InputArea
+            size="lg"
+            variant="default"
+            type="password"
+            name="checkPassword"
+            value={password.checkPassword}
+            placeholder="비밀번호를 확인해주세요."
+            onChange={handleCheckPasswordChange}
+            minLength="8"
+            maxLength="16"
+            required
+            style={{
+              borderColor: passwordError
+                ? LightTheme.PRIMARY_NORMAL
+                : !passwordError &&
+                  password.checkPassword &&
+                  password.password === password.checkPassword
+                ? LightTheme.STATUS_POSITIVE
+                : LightTheme.GRAY_400,
+            }}
+            onKeyDown={(e) => {
+              if (e.key === ' ') e.preventDefault();
+            }}
+          />
+          {!passwordError &&
+            password.checkPassword &&
+            password.password === password.checkPassword && (
+              <img
+                src="Group 2066.png"
+                alt="Valid password"
+                style={{
+                  position: 'absolute',
+                  top: '12px',
+                  right: '12px',
+                  width: '20px',
+                  height: '20px',
+                }}
+              />
+            )}
+        </div>
+        {passwordError ? (
+          <p
+            style={{
+              color: LightTheme.PRIMARY_NORMAL,
+              fontSize: '12px',
+              marginTop: '5px',
+              position: 'absolute',
+            }}
+          >
             비밀번호가 일치하지 않습니다.
           </p>
-        )}
-        {!passwordError && (
-          <p style={{ color: 'red', fontSize: '12px' }}>
+        ) : !passwordError &&
+          password.checkPassword &&
+          password.password === password.checkPassword ? (
+          <p
+            style={{
+              color: LightTheme.STATUS_POSITIVE,
+              fontSize: '12px',
+              marginTop: '5px',
+              position: 'absolute',
+            }}
+          >
             비밀번호가 일치합니다.
           </p>
+        ) : (
+          <></>
         )}
         <div className="twoButton">
           <button className="cancel" onClick={handleClick}>
@@ -211,6 +313,7 @@ const Container = styled.div`
   }
   .twoButton {
     display: flex;
+    margin-top: 30px;
     justify-content: flex-end;
     gap: 12px;
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,10 @@ const App = () => {
     <div>
       <HeadInfo title="만나잔에 오신걸 환영합니다!" />
       <MainFirstSection />
-      <MainSecondSection />
+      <div style={{ display: 'flex', marginTop: '-200px' }}>
+        <MainSecondSection />
+      </div>
+
       <MainLastSectionMovie />
     </div>
   );


### PR DESCRIPTION
1. 인풋 스타일 찾기 . 및 액티브시 보더 컬러 적용 
2.로그인 회원가입 유저 정보 셋팅 인풋 란에 띄워쓰기 못하게 조건 걸기 했습니다. 
3.로그인시 액티브 된 인풋 보더 초록색 띄워주기
4.로그인 모달에서 이메일 찾기 인풋창에 모드 잘못 적용해서 휴재번호 찾기 란 컬러 값변동 벗는 것 수정
5. 이메일 찾기 버튼 누르고 로그인 다녀올 때 input 창 비워주기 
6.회원가입 비밀번호 유효성 확인 되면 비밀번호 확인란까지 같이 초록색 으로 통과 표시 되는것 수정  
7. 비밀번호 변경시 비밀번호 유효성 확인 되면 비밀번호 확인란까지 같이 초록색 으로 통과 표시 되는것 수정  
8. 비밀번호 찾기 이후 로그인시 뜨는 비밀번호 변경페이지 비밀번호 유효성 확인 되면 비밀번호 확인란까지 같이 초록색 으로 통과 표시 되는것 수정 
9. 댓글 수정 삭제하기  css 수정 호버시 색 변환 및 수정 삭제 -> 수정하기 삭제하기 변환  답글달기와 위치 변환
10. 대댓글 수정 삭제 버튼 -> 수정하기 삭제하기로 변환 및 호버시 색변환 , 대댓글 입력 상태의 css 수정 
11. 캘린더 입력할 때 입력한 글자 수 페이지에 바로 보이게 (ex: 12/500)
12. 인풋에 maxLength 걸어줌 
13.페이지네이션 수정 -> 전에 페이지 숫자가 고정되지 않고 움직던 것을 데이터 배열에 크게 박스 영역 잡아주고 
페이지네이션 영역 바깥으로 빼서 숫자 위치 고정되도록      -> 캘린더 , 좋아요 리스트 (술집,게시물), 내가쓴 게시물 
14. 술집 리스트 좋아요 보여줄 때 사진 배열 Post.PostList[0].S3Url 이 없으면 맥주 사진 이미지로 나오게 조건
15. 메인 페이지 두번ㄷ째 섹션 스크롤 길다고 해서 줄여줬습니다. 

close #347