### PR TITLE
만료시 새로고침

### DIFF
--- a/src/shared/instance.js
+++ b/src/shared/instance.js
@@ -31,7 +31,9 @@ instance.interceptors.response.use(
         const accessToken = response.data.access_token;
         cookies.set('access_token', accessToken);
         originalRequest.headers.cookies = `${accessToken}`;
-        return axios(originalRequest);
+        const result = await axios(originalRequest);
+        // window.location.reload(); // 새로고침 추가
+        return result;
       }
     }
     if (error.response.data.statusCode === 400 && !originalRequest._retry) {


### PR DESCRIPTION
어세스 토큰 만료시 헤더에 리프레시토큰 넣어줘서 새 어세스토큰 받아오고 다시 갈아줍니다.
그러나 새로고침을 해야만 정상적으로 갈아져서 , 새로고침 해주는 코드를 추가햇습니다.