### PR TITLE
[fix] MapAppoinment.js에서 SelectedDate값 밀리는 버그 해결.

### DIFF
--- a/src/features/map/MapAppointment.js
+++ b/src/features/map/MapAppointment.js
@@ -39,7 +39,16 @@ const MapAppointment = ({checkedPlace}) => {
     y,
     selectedDate: appointment,
   };
-
+  // selecetedDate & mutate Handler
+  const selectAppointmentHandler = () => {
+    const formattedDate = moment(value).format('YYYY-MM-DD');
+    setAppointment(formattedDate);
+    const updatedMapRequestDto = {
+      ...mapRequestDto,
+      selectedDate: formattedDate,
+    };
+    mutate(updatedMapRequestDto);
+  };
   //
   const token = cookies.get('access_token');
   const { mutate } = useMutation({
@@ -76,11 +85,7 @@ const MapAppointment = ({checkedPlace}) => {
   const clickDayHandler = (value, event) => {
     alert(`Clicked day:  ${moment(value).format('YYYY-MM-DD')}`);
   };
-  //value -> 원래 형태 'YYYY년 MM월 DD일' , 'YYYY-MM-DD', 'MM-DD' 이런식으로 변경이 가능합니다
-  const selectAppointmentHandler = () => {
-    setAppointment(moment(value).format('YYYY-MM-DD'));
-    mutate(mapRequestDto);
-  };
+
   const nickName =
     typeof window !== 'undefined'
       ? localStorage.getItem('nick_name') ?? ''
@@ -107,7 +112,7 @@ const MapAppointment = ({checkedPlace}) => {
                       <AppointmentPlaceWrapper>
                         <div className="AppointmentPlace">중간 위치에 있는 술집을 선택해 주세요.</div>
                         {checkedPlace ? (
-                          <span className="PlaceChecked">" {checkedPlace?.place_name} "</span>
+                          <span className="PlaceChecked"> {checkedPlace?.place_name} </span>
                         ) : (
                           <span className="PlaceUnchecked" style={{color: `${LightTheme.FONT_SECONDARY}`}}>목록에서 선택해 주세요.</span>
                         )}
@@ -165,7 +170,7 @@ const MapAppointment = ({checkedPlace}) => {
                     <AppointmentPlaceWrapper>
                       <div className="AppointmentPlace">중간 위치에 있는 술집을 선택해 주세요.</div>
                           {checkedPlace ? (
-                            <span className="PlaceChecked">" {checkedPlace?.place_name} "</span>
+                            <span className="PlaceChecked">&quot; {checkedPlace?.place_name} &quot;</span>
                           ) : (
                             <span className="PlaceUnchecked" style={{ color: `${LightTheme.FONT_SECONDARY}` }}>목록에서 선택해 주세요.</span>
                           )}
@@ -180,7 +185,7 @@ const MapAppointment = ({checkedPlace}) => {
                       </p>
                       <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                       <ButtonText size="lg" variant="primary" label="약속잡기"
-                        onClick={() => {selectAppointmentHandler()}}
+                        onClick={selectAppointmentHandler}
                         style={{  marginTop: '5vh' }}/>
                       </div>
                   </div>


### PR DESCRIPTION
 MapAppoinment.js에서 SelectedDate값 밀리는 버그 해결.
문제의 원인은 useState와 useEffect의 비동기적인 특성 때문. useState로 설정된 값을 바로 가져오는 것이 아니라, useState가 실행된 후 useEffect가 실행되기 전까지 시간적 차이가 발생할 수 있다. 따라서, mapRequestDto를 직접 사용하는 것이 아니라, selectAppointmentHandler 함수 내에서 값을 가공하여 사용하면 해결된다. 예를 들어, selectAppointmentHandler 함수 내에서 아래와 같이 appointment 값을 이용하여 mapRequestDto를 가공한다.
버그났던 코드:
  const selectAppointmentHandler = () => {
    setAppointment(moment(value).format('YYYY-MM-DD'));
    mutate(mapRequestDto);
  };
  
 해결코드:
const selectAppointmentHandler = () => {
  const formattedDate = moment(value).format('YYYY-MM-DD');
  setAppointment(formattedDate);
  const updatedMapRequestDto = {
    ...mapRequestDto,
    selectedDate: formattedDate,
  };
  mutate(updatedMapRequestDto);
};